### PR TITLE
Update Dockerfile

### DIFF
--- a/lair2/Dockerfile
+++ b/lair2/Dockerfile
@@ -32,7 +32,7 @@ RUN chmod +x api-server_linux_amd64
 
 # Caddy Reverse Proxy
 WORKDIR /root/lair
-RUN curl -o caddy.tar.gz 'http://caddyserver.com/download/build?os=linux&arch=amd64&features='
+RUN curl -o caddy.tar.gz 'https://caddyserver.com/download/build?os=linux&arch=amd64&features='
 RUN tar -zxvf caddy.tar.gz
 RUN openssl req -days 3650 -new -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 9999 -subj "/C=US/ST=LAIR/L=Lairville/O=Dis/CN=www.lair.fun"
 RUN printf '0.0.0.0:11013\ntls cert.pem key.pem\nproxy /api localhost:11015\nproxy / localhost:11014 {\n  websocket\n}\n' > Caddyfile


### PR DESCRIPTION
Changed curl address for caddy to HTTPS instead of HTTP (which is now a redirect).